### PR TITLE
Use previous VS2019 image for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
  
 configuration:
   - Release


### PR DESCRIPTION
Appveyor has updated to latest VS2019 build, which does not include Core SDK 3.1.101.
GitVersion has a current bug with later SDK versions - until this is fixed, we must target the earlier version.